### PR TITLE
Bump Clojure dependency to 1.3.0, clojure.java.jdbc to 0.2.2

### DIFF
--- a/ragtime.core/project.clj
+++ b/ragtime.core/project.clj
@@ -1,3 +1,3 @@
-(defproject ragtime/ragtime.core "0.2.0"
+(defproject ragtime/ragtime.core "0.3.0-SNAPSHOT"
   :description "A database-independent migration library"
-  :dependencies [[org.clojure/clojure "1.2.1"]])
+  :dependencies [[org.clojure/clojure "1.3.0"]])

--- a/ragtime.sql/project.clj
+++ b/ragtime.sql/project.clj
@@ -1,6 +1,6 @@
-(defproject ragtime/ragtime.sql "0.2.0"
+(defproject ragtime/ragtime.sql "0.3.0-SNAPSHOT"
   :description "Ragtime migrations for SQL databases"
-  :dependencies [[org.clojure/clojure "1.2.1"]
+  :dependencies [[org.clojure/clojure "1.3.0"]
                  [ragtime/ragtime.core "0.2.0"]
-                 [org.clojure/java.jdbc "0.1.1"]]
+                 [org.clojure/java.jdbc "0.2.2"]]
   :dev-dependencies [[com.h2database/h2 "1.3.160"]])


### PR DESCRIPTION
Sorry for submitting two things in one pull request but they seemed minor and innocent enough.

A lot of folks have moved on to Clojure 1.3 by now. I think 1.3 makes more sense as a default version to depend on. Because ragtime is small, it won't be a problem for 1.2 users.

If you agree to migrate to Leiningen 2 and add travis-ci.org, I will be happy to set up testing against 4 Clojure versions (1.2.1 to 1.5 master snapshots) and 3 JDKs. Let me know.
