### PR TITLE
SQL-92 compatibility

### DIFF
--- a/ragtime.sql/src/ragtime/sql/database.clj
+++ b/ragtime.sql/src/ragtime/sql/database.clj
@@ -2,7 +2,8 @@
   (:use [ragtime.core :only (Migratable connection)])
   (:require [clojure.java.jdbc :as sql]
             [clojure.java.io :as io])
-  (:import (java.util Date)))
+  (:import (java.util Date)
+           (java.sql Timestamp)))
 
 (def ^:private migrations-table "ragtime_migrations")
 
@@ -12,7 +13,7 @@
     (try
       (sql/create-table migrations-table
                         [:id "varchar(255)"]
-                        [:created_at "datetime"])
+                        [:created_at "timestamp"])
       (catch Exception _))))
 
 (defrecord SqlDatabase []
@@ -21,8 +22,8 @@
     (sql/with-connection db
       (ensure-migrations-table-exists db)
       (sql/insert-values migrations-table
-                         [:id :created_at] [(str id) (Date.)])))
-  
+                         [:id :created_at] [(str id) (Timestamp. (.getTime (Date.)))])))
+
   (remove-migration-id [db id]
     (sql/with-connection db
       (ensure-migrations-table-exists db)


### PR DESCRIPTION
Hi James,

I tried to get ragtime working with a PostgreSQL database but
failed, because PostgreSQL doesn't have the DATETIME type. I
think this is specific to MySQL. This patch changes the
created_at column to be a TIMESTAMP type, which is defined in
SQL-92 in should work with a wider range of databases.

What do you think?

Roman.
