### PR TITLE
Upgrade leinjacker to remove error on 'lein ragtime migrate'

### DIFF
--- a/ragtime.lein/project.clj
+++ b/ragtime.lein/project.clj
@@ -1,4 +1,4 @@
 (defproject ragtime/ragtime.lein "0.3.2"
   :description "A leiningen plugin for Ragtime."
-  :dependencies [[leinjacker "0.2.0"]]
+  :dependencies [[leinjacker "0.4.1"]]
   :eval-in-leiningen true)


### PR DESCRIPTION
I was getting an exception when running 'lein ragtime migrate'

For example:

``` shell
git checkout git@github.com:weavejester/ragtime.git &&
cd ragtime/ragtime.lein &&
lein ragtime migrate 
```

Raise this exception:

``` shell
Exception in thread "main" java.lang.AssertionError: Assert failed: (vector? (:dependencies project []))
    at leinjacker.deps$add_if_missing.invoke(deps.clj:43)
    at leiningen.ragtime$add_ragtime_deps.invoke(ragtime.clj:7)
    at leiningen.ragtime$ragtime.doInvoke(ragtime.clj:15)
    at clojure.lang.RestFn.invoke(RestFn.java:425)
    at clojure.lang.Var.invoke(Var.java:419)
    at clojure.lang.AFn.applyToHelper(AFn.java:163)
    at clojure.lang.Var.applyTo(Var.java:532)
    at clojure.core$apply.invoke(core.clj:603)
    at leiningen.core.main$resolve_task$fn__1606.doInvoke(main.clj:132)
    at clojure.lang.RestFn.applyTo(RestFn.java:139)
    at clojure.lang.AFunction$1.doInvoke(AFunction.java:29)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:603)
    at leiningen.core.main$apply_task.invoke(main.clj:167)
    at leiningen.core.main$_main$fn__1665.invoke(main.clj:237)
    at leiningen.core.main$_main.doInvoke(main.clj:221)
    at clojure.lang.RestFn.invoke(RestFn.java:421)
    at clojure.lang.Var.invoke(Var.java:419)
    at clojure.lang.AFn.applyToHelper(AFn.java:163)
    at clojure.lang.Var.applyTo(Var.java:532)
    at clojure.core$apply.invoke(core.clj:601)
    at clojure.main$main_opt.invoke(main.clj:324)
    at clojure.main$main.doInvoke(main.clj:427)
    at clojure.lang.RestFn.invoke(RestFn.java:457)
    at clojure.lang.Var.invoke(Var.java:427)
    at clojure.lang.AFn.applyToHelper(AFn.java:172)
    at clojure.lang.Var.applyTo(Var.java:532)
    at clojure.main.main(main.java:37)
```

Upgrading leinjacker fixed this.
