### PR TITLE
Load migrations function namespace before calling core/connection multi

### DIFF
--- a/ragtime.core/src/ragtime/main.clj
+++ b/ragtime.core/src/ragtime/main.clj
@@ -27,13 +27,20 @@
   (map verbose-migration ((load-var migration-fn))))
 
 (defn migrate [{:keys [database migrations]}]
-  (core/migrate-all
-   (core/connection database)
-   (resolve-migrations migrations)))
+
+  ;; We want to resolve migrations fn before calling core/connection
+  (let [migrations-col (resolve-migrations migrations)]
+    (core/migrate-all
+     (core/connection database)
+     migrations-col)))
 
 (defn rollback [{:keys [database migrations]} & [n]]
-  (let [db (core/connection database)]
-    (doseq [m (resolve-migrations migrations)]
+
+  ;; We want to resolve migrations fn before calling core/connection
+  (let [migrations-col (resolve-migrations migrations)
+        db (core/connection database)]
+
+    (doseq [m migrations-col]
       (core/remember-migration m))
     (core/rollback-last db (or n 1))))
 


### PR DESCRIPTION
I really like ragtimes' approach.  I'm starting to use ragtime with mongodb.

One minor issue I run into when using `lein ragtime` is that I must pass `-r myns` in order to load the namespace that implements the `core/connection` multimethod.

Now, the namespace that holds my migrations function already depends on the namespace that implements `connection` for mongodb. So, simply resolving the migration function before calling `connection` solves my problem.

I also see that ragtime lein  has [`-r ragtime.sql.database`  hardcoded](https://github.com/weavejester/ragtime/blob/master/ragtime.lein/src/leiningen/ragtime.clj#L18) in there. I think that if ragtime.sql.files required `ragtime.sql.database` (which is not too bad I think) then this hardcoding could be removed. If you agree, I'd be happy to also make this change.

Thanks,
Fer
