### PR TITLE
Fix ClassCastException when specifying the number of versions to rollback

### DIFF
--- a/ragtime.core/src/ragtime/main.clj
+++ b/ragtime.core/src/ragtime/main.clj
@@ -35,7 +35,8 @@
   (let [db (core/connection database)]
     (doseq [m (resolve-migrations migrations)]
       (core/remember-migration m))
-    (core/rollback-last db (or n 1))))
+    (core/rollback-last db (or (when n (Integer/parseInt n)) 
+                               1))))
 
 (defn- parse-args [args]
   (cli args


### PR DESCRIPTION
If given, parse the 'versions' command line argument as an integer before handing it off to core/rollback-last, which expects an integer.
