### PR TITLE
Print stack trace of wrapped SQLException

### DIFF
--- a/ragtime.sql.files/src/ragtime/sql/files.clj
+++ b/ragtime.sql.files/src/ragtime/sql/files.clj
@@ -70,8 +70,13 @@
   (fn [db]
     (sql/with-connection db
       (sql/transaction
-       (doseq [s (sql-statements (slurp file))]
-         (sql/do-commands s))))))
+       (try
+         (doseq [s (sql-statements (slurp file))]
+           (sql/do-commands s))
+         (catch java.sql.SQLException e
+           (if (.getNextException e)
+             (.printStackTrace (.getNextException e)))
+           (throw e)))))))
 
 (defn- make-migration [[id [down up]]]
   {:id   id


### PR DESCRIPTION
In PostgreSQL, in case there is SQLException during migration, the stack trace printed out is a generic statement like: 

Exception in thread "main" java.sql.BatchUpdateException: Batch entry 0 alter table foo rename column bar to bar2 was aborted.  Call getNextException to see the cause.

This patch will get next exception and print out stack trace for the root cause of this failure. The result will look like below: 

org.postgresql.util.PSQLException: ERROR: relation "foo" does not exist
...
Exception in thread "main" java.sql.BatchUpdateException: Batch entry 0 alter table foo rename column bar to bar2 was aborted.  Call getNextException to see the cause.eError(QueryExecutorImpl.java:457)
