### PR TITLE
Update java.jdbc to 0.3.0.

### DIFF
--- a/ragtime.sql.files/project.clj
+++ b/ragtime.sql.files/project.clj
@@ -1,7 +1,8 @@
 (defproject ragtime/ragtime.sql.files "0.3.4"
   :description "Ragtime adapter that reads migrations from SQL files."
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.clojure/java.jdbc "0.2.3"]]
+                 [org.clojure/java.jdbc "0.3.0"]
+                 [java-jdbc/dsl "0.1.0"]]
   :profiles
   {:dev {:dependencies [[com.h2database/h2 "1.3.160"]
                         [ragtime/ragtime.sql "0.3.4"]]}})

--- a/ragtime.sql.files/src/ragtime/sql/files.clj
+++ b/ragtime.sql.files/src/ragtime/sql/files.clj
@@ -68,10 +68,9 @@
 
 (defn- run-sql-fn [file]
   (fn [db]
-    (sql/with-connection db
-      (sql/transaction
+      (sql/with-db-transaction [conn db]
        (doseq [s (sql-statements (slurp file))]
-         (sql/do-commands s))))))
+         (sql/db-do-commands conn s)))))
 
 (defn- make-migration [[id [down up]]]
   {:id   id

--- a/ragtime.sql.files/test/ragtime/sql/test/files.clj
+++ b/ragtime.sql.files/test/ragtime/sql/test/files.clj
@@ -9,12 +9,11 @@
 (def test-db
   (connection "jdbc:h2:mem:test_db;DB_CLOSE_DELAY=-1"))
 
-(defn table-exists? [table-name]
+(defn table-exists? [conn table-name]
   (not-empty
-   (sql/with-query-results rs
+   (sql/query conn
      ["select true from information_schema.tables where table_name = ?"
-      (str/upper-case table-name)]
-     (vec rs))))
+      (str/upper-case table-name)])))
 
 (deftest test-sql-statements
   (are [x y] (= (sql-statements x) y)
@@ -33,6 +32,6 @@
       (is (= (count migs) 1))
       (is (= (:id (first migs)) "20111202110600-create-foo-table"))
       (migrate-all test-db migs)
-      (sql/with-connection test-db
-        (is (table-exists? "ragtime_migrations"))
-        (is (table-exists? "foo"))))))
+      (sql/with-db-connection [conn test-db]
+        (is (table-exists? conn "ragtime_migrations"))
+        (is (table-exists? conn "foo"))))))

--- a/ragtime.sql/project.clj
+++ b/ragtime.sql/project.clj
@@ -2,6 +2,7 @@
   :description "Ragtime migrations for SQL databases"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [ragtime/ragtime.core "0.3.4"]
-                 [org.clojure/java.jdbc "0.2.3"]]
+                 [org.clojure/java.jdbc "0.3.0"]
+                 [java-jdbc/dsl "0.1.0"]]
   :profiles
   {:dev {:dependencies [[com.h2database/h2 "1.3.160"]]}})

--- a/ragtime.sql/src/ragtime/sql/database.clj
+++ b/ragtime.sql/src/ragtime/sql/database.clj
@@ -1,20 +1,21 @@
 (ns ragtime.sql.database
   (:use [ragtime.core :only (Migratable connection)])
   (:require [clojure.java.jdbc :as sql]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [java-jdbc.ddl :as ddl])
   (:import java.util.Date
            java.text.SimpleDateFormat))
 
 (def ^:private migrations-table "ragtime_migrations")
 
-(defn ^:internal ensure-migrations-table-exists [db]
+(defn ^:internal ensure-migrations-table-exists [conn]
   ;; TODO: is there a portable way to detect table existence?
-  (sql/with-connection db
     (try
-      (sql/create-table migrations-table
-                        [:id "varchar(255)"]
-                        [:created_at "varchar(32)"])
-      (catch Exception _))))
+      (sql/db-do-commands conn
+        (ddl/create-table migrations-table
+                          [:id "varchar(255)"]
+                          [:created_at "varchar(32)"]))
+      (catch Exception _)))
 
 (defn format-datetime [dt]
   (-> (SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss.SSS")
@@ -23,23 +24,23 @@
 (defrecord SqlDatabase []
   Migratable
   (add-migration-id [db id]
-    (sql/with-connection db
-      (ensure-migrations-table-exists db)
-      (sql/insert-values migrations-table
-                         [:id :created_at]
-                         [(str id) (format-datetime (Date.))])))
-  
+    (sql/with-db-connection [conn db]
+      (ensure-migrations-table-exists conn)
+      (sql/insert! conn migrations-table
+                   [:id :created_at]
+                   [(str id) (format-datetime (Date.))])))
+
   (remove-migration-id [db id]
-    (sql/with-connection db
-      (ensure-migrations-table-exists db)
-      (sql/delete-rows migrations-table ["id = ?" id])))
+    (sql/with-db-connection [conn db]
+      (ensure-migrations-table-exists conn)
+      (sql/delete! conn migrations-table ["id = ?" id])))
 
   (applied-migration-ids [db]
-    (sql/with-connection db
-      (ensure-migrations-table-exists db)
-      (sql/with-query-results results
+    (sql/with-db-connection [conn db]
+      (ensure-migrations-table-exists conn)
+      (map :id (sql/query conn
         ["SELECT id FROM ragtime_migrations ORDER BY created_at"]
-        (vec (map :id results))))))
+        )))))
 
 (defmethod connection "jdbc" [url]
   (map->SqlDatabase {:connection-uri url}))

--- a/ragtime.sql/test/ragtime/sql/test/database.clj
+++ b/ragtime.sql/test/ragtime/sql/test/database.clj
@@ -8,13 +8,7 @@
   (:require [clojure.java.jdbc :as sql]))
 
 (def test-db
-  (connection "jdbc:h2:mem:test_db"))
-
-(defn h2-fixture [f]
-  (sql/with-connection test-db
-    (f)))
-
-(use-fixtures :each h2-fixture)
+  (connection "jdbc:h2:mem:test_db;DB_CLOSE_DELAY=-1"))
 
 (deftest test-add-migrations
   (add-migration-id test-db "12")


### PR DESCRIPTION
java.jdbc 0.3.0 contains breaking changes: DDL functionality has
been moved to java-jdbc/dsl and API has changed. This commit
modifies ragtime to work with java.jdbc 0.3.0 and to use DDL
functionality from java-jdbc/dsl 0.1. Ragtime no longer works with
java.jdbc 0.2.3 after this commit. Fixes issue #23.
