### PR TITLE
Upgrade to clojure.java.jdbc 0.3.2.

### DIFF
--- a/ragtime.sql.files/project.clj
+++ b/ragtime.sql.files/project.clj
@@ -1,7 +1,7 @@
 (defproject ragtime/ragtime.sql.files "0.3.4"
   :description "Ragtime adapter that reads migrations from SQL files."
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.clojure/java.jdbc "0.2.3"]]
+                 [org.clojure/java.jdbc "0.3.2"]]
   :profiles
   {:dev {:dependencies [[com.h2database/h2 "1.3.160"]
                         [ragtime/ragtime.sql "0.3.4"]]}})

--- a/ragtime.sql.files/src/ragtime/sql/files.clj
+++ b/ragtime.sql.files/src/ragtime/sql/files.clj
@@ -1,6 +1,6 @@
 (ns ragtime.sql.files
   (:require [clojure.java.io :as io]
-            [clojure.java.jdbc :as sql]
+            [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]))
 
 (def ^:private migration-pattern
@@ -68,10 +68,9 @@
 
 (defn- run-sql-fn [file]
   (fn [db]
-    (sql/with-connection db
-      (sql/transaction
-       (doseq [s (sql-statements (slurp file))]
-         (sql/do-commands s))))))
+    (jdbc/with-db-transaction [conn db]
+      (doseq [statement (sql-statements (slurp file))]
+        (jdbc/execute! conn [statement])))))
 
 (defn- make-migration [[id [down up]]]
   {:id   id

--- a/ragtime.sql.files/test/ragtime/sql/test/files.clj
+++ b/ragtime.sql.files/test/ragtime/sql/test/files.clj
@@ -1,5 +1,5 @@
 (ns ragtime.sql.test.files
-  (:require [clojure.java.jdbc :as sql]
+  (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str])
   (:use clojure.test
         ragtime.sql.files
@@ -11,10 +11,9 @@
 
 (defn table-exists? [table-name]
   (not-empty
-   (sql/with-query-results rs
+   (jdbc/query test-db
      ["select true from information_schema.tables where table_name = ?"
-      (str/upper-case table-name)]
-     (vec rs))))
+      (str/upper-case table-name)])))
 
 (deftest test-sql-statements
   (are [x y] (= (sql-statements x) y)
@@ -33,6 +32,5 @@
       (is (= (count migs) 1))
       (is (= (:id (first migs)) "20111202110600-create-foo-table"))
       (migrate-all test-db migs)
-      (sql/with-connection test-db
-        (is (table-exists? "ragtime_migrations"))
-        (is (table-exists? "foo"))))))
+      (is (table-exists? "ragtime_migrations"))
+      (is (table-exists? "foo")))))

--- a/ragtime.sql/project.clj
+++ b/ragtime.sql/project.clj
@@ -2,6 +2,6 @@
   :description "Ragtime migrations for SQL databases"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [ragtime/ragtime.core "0.3.4"]
-                 [org.clojure/java.jdbc "0.2.3"]]
+                 [org.clojure/java.jdbc "0.3.2"]]
   :profiles
   {:dev {:dependencies [[com.h2database/h2 "1.3.160"]]}})

--- a/ragtime.sql/test/ragtime/sql/test/database.clj
+++ b/ragtime.sql/test/ragtime/sql/test/database.clj
@@ -5,13 +5,13 @@
                              remove-migration-id
                              applied-migration-ids
                              connection]])
-  (:require [clojure.java.jdbc :as sql]))
+  (:require [clojure.java.jdbc :as jdbc]))
 
 (def test-db
   (connection "jdbc:h2:mem:test_db"))
 
 (defn h2-fixture [f]
-  (sql/with-connection test-db
+  (jdbc/with-db-connection [_ test-db] ; keep a connection open to keep the DB in memory for the whole test
     (f)))
 
 (use-fixtures :each h2-fixture)


### PR DESCRIPTION
This uses the current stable release of clojure.java.jdbc, which is unfortunately not backward compatible with the previous version ragtime used (0.2.3). To support this change in ragtime apps that use it must be able to upgrade to clojure.java.jdbc 0.3.x. The clojure.java.jdbc.deprecated namespace in that project includes the 0.2.x compatible functions to ease migration though.
