### PR TITLE
Exclude non-project compiled classes

### DIFF
--- a/ragtime.core/project.clj
+++ b/ragtime.core/project.clj
@@ -2,4 +2,6 @@
   :description "A database-independent migration library"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojure/tools.cli "0.2.2"]]
+  :aot [ragtime.main]
+  :clean-non-project-classes true
   :main ragtime.main)


### PR DESCRIPTION
Monger depends on ragtime.core which forces users of Monger to use tools.cli 0.2.2 because it gets compiled into ragtime.core. This PR excludes tools.cli classes from the ragtime.core JAR, enabling it to be used as a library in other projects that rely on earlier tools.cli versions.
