### PR TITLE
support to load migrations from the classpath

### DIFF
--- a/ragtime.sql.files/project.clj
+++ b/ragtime.sql.files/project.clj
@@ -1,7 +1,8 @@
 (defproject ragtime/ragtime.sql.files "0.3.4"
   :description "Ragtime adapter that reads migrations from SQL files."
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.clojure/java.jdbc "0.2.3"]]
+                 [org.clojure/java.jdbc "0.2.3"]
+                 [org.clojure/java.classpath "0.2.2"]]
   :profiles
   {:dev {:dependencies [[com.h2database/h2 "1.3.160"]
                         [ragtime/ragtime.sql "0.3.4"]]}})

--- a/ragtime.sql.files/test/ragtime/sql/test/files.clj
+++ b/ragtime.sql.files/test/ragtime/sql/test/files.clj
@@ -35,4 +35,12 @@
       (migrate-all test-db migs)
       (sql/with-connection test-db
         (is (table-exists? "ragtime_migrations"))
+        (is (table-exists? "foo")))))
+  (testing "custom migration directory in classpath"
+    (let [migs (migrations "classpath:migrations")]
+      (is (= (count migs) 1))
+      (is (= (:id (first migs)) "20111202110600-create-foo-table"))
+      (migrate-all test-db migs)
+      (sql/with-connection test-db
+        (is (table-exists? "ragtime_migrations"))
         (is (table-exists? "foo"))))))


### PR DESCRIPTION
hello,

this pull request adds support to load migrations from the classpath. I'm not sure if you want this to be part of ragtime.sql.files or if you will prefer to add loading migrations from the classpath in the new module.

I'm be happy to create a new module if you thing that's a better approach.

Sorry about having to bump up the clojure version to 1.5.1. I'm using Lighttable, which requires clojure 1.5.