### PR TITLE
allow URL-unsafe characters inside raw JDBC connection-uri

### DIFF
--- a/ragtime.core/src/ragtime/core.clj
+++ b/ragtime.core/src/ragtime/core.clj
@@ -1,7 +1,7 @@
 (ns ragtime.core
   "Functions and macros for defining and applying migrations."
-  (:require [ragtime.strategy :as strategy])
-  (:import java.net.URI))
+  (:require [ragtime.strategy :as strategy]
+            [clojure.string :as str]))
 
 (defprotocol Migratable
   "Protocol for a database that cab be migrated."
@@ -16,7 +16,7 @@
   "Create a Migratable database connection from a URL. Dispatches on the URL
   scheme."
   (fn [url]
-    (.getScheme (URI. url))))
+    (first (str/split url #":"))))
 
 (defonce defined-migrations (atom {}))
 


### PR DESCRIPTION
`ragtime.core/connection` tries to parse the raw-connection-string as a URI which fails if the string contains unsafe characters like `%`. 
Our password contained such characters which lead to `java.net.URISyntaxException: Malformed escape pair ...` when trying to run `lein ragtime migrate`.
Not sure if proposed fix is a hack, otherwise unsafe characters would have to be percent-encoded inside the project.clj/profiles.clj and parsed inside ragtime, which only adds confusion IMHO.

Cheers!
