### PR TITLE
SQL Resources Adapter

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,11 +2,13 @@
   :description "A database-independent migration library"
   :dependencies [[ragtime/ragtime.core "0.3.8"]
                  [ragtime/ragtime.sql "0.3.8"]
-                 [ragtime/ragtime.sql.files "0.3.8"]]
+                 [ragtime/ragtime.sql.files "0.3.8"]
+                 [ragtime/ragtime.sql.resources "0.3.8"]]
   :plugins [[lein-sub "0.2.1"]
             [codox "0.8.10"]]
-  :sub ["ragtime.core" "ragtime.sql" "ragtime.sql.files"]
+  :sub ["ragtime.core" "ragtime.sql" "ragtime.sql.files" "ragtime.sql.resources"]
   :codox {:sources ["ragtime.core/src"
                     "ragtime.sql/src"
-                    "ragtime.sql.files/src"]
+                    "ragtime.sql.files/src"
+                    "ragtime.sql.resources/src"]
           :exclude [ragtime.sql.database ragtime.main]})

--- a/ragtime.sql.resources/project.clj
+++ b/ragtime.sql.resources/project.clj
@@ -1,0 +1,10 @@
+(defproject ragtime/ragtime.sql.resources "0.3.8"
+  :description "Ragtime adapter that reads migrations from SQL resources."
+  :dependencies [[org.clojure/clojure "1.3.0"]
+                 [org.clojure/java.jdbc "0.2.3"]
+                 [ragtime/ragtime.sql "0.3.8"]
+                 [ragtime/ragtime.sql.files "0.3.8"]]
+  :profiles
+  {:dev {:dependencies [[com.h2database/h2 "1.3.160"]]}
+   :test {:resource-paths ["test/resources"]}
+   :java-jdbc-0.3.x [:dev {:dependencies [[org.clojure/java.jdbc "0.3.2"]]}]})

--- a/ragtime.sql.resources/src/ragtime/sql/resources.clj
+++ b/ragtime.sql.resources/src/ragtime/sql/resources.clj
@@ -1,0 +1,31 @@
+(ns ragtime.sql.resources
+  "Specify migrations as SQL resources.
+  Useful when you'd like your migration scripts to be compiled into your jar."
+  (:require [clojure.java.io :as io]
+            [ragtime.sql.files :as rsf]))
+
+(def ^:private default-dir "migrations")
+
+(defn- id->resources [dir id]
+  (->> (for [suffix [".down" ".up"]] (str dir "/" id suffix ".sql"))
+       (map io/resource)))
+
+(defn migrations
+  "Returns a function that returns a list of migrations to apply.
+
+  Since resources must be found on the classpath, they are not conveniently
+  discoverable like regular files (at least, not without heriocs). Pass a list
+  of resource names that should be considered as SQL migration files.
+
+  All migration resources should live under a single directory. By default,
+  this is set to 'migrations/', however you may optionally pass an alternative."
+  ([ids]
+    (migrations ids default-dir))
+  ([ids dir]
+    (fn []
+      (let [resources (map (partial id->resources dir) ids)]
+        (assert (every? identity resources)
+                (str "Invalid migration resource names. "
+                     "Make sure your names correspond to actual resources "
+                     "on the classpath."))
+        (rsf/files->migrations (map vector ids resources))))))

--- a/ragtime.sql.resources/test/ragtime/sql/test/resources.clj
+++ b/ragtime.sql.resources/test/ragtime/sql/test/resources.clj
@@ -1,0 +1,35 @@
+(ns ragtime.sql.test.resources
+  (:require [clojure.string :as str])
+  (:use clojure.test
+        ragtime.sql.resources
+        ragtime.sql.database
+        ragtime.core))
+
+(ragtime.sql.database/require-jdbc 'sql)
+
+(def test-db
+  (connection "jdbc:h2:mem:test_db;DB_CLOSE_DELAY=-1"))
+
+(defn table-exists? [table-name]
+  (not-empty
+   (sql/with-query-results rs
+     ["select true from information_schema.tables where table_name = ?"
+      (str/upper-case table-name)]
+     (vec rs))))
+
+(deftest test-migrations
+  (let [mig-id "20111202110600-create-foo-table"
+        migs ((migrations [mig-id]))]
+    (is (= (count migs) 1))
+    (is (= (:id (first migs)) mig-id))
+    (migrate-all test-db migs)
+    (sql/with-connection test-db
+      (is (table-exists? "ragtime_migrations"))
+      (is (table-exists? "foo")))))
+
+(deftest test-incomplete-migrations
+  (is (thrown-with-msg? AssertionError
+                        #"Incomplete migrations"
+                        ((migrations
+                          ["migration1" "migration2"]
+                          "incomplete-migrations")))))

--- a/ragtime.sql.resources/test/resources/incomplete-migrations/migration1.up.sql
+++ b/ragtime.sql.resources/test/resources/incomplete-migrations/migration1.up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE foo ( id SERIAL );

--- a/ragtime.sql.resources/test/resources/incomplete-migrations/migration2.down.sql
+++ b/ragtime.sql.resources/test/resources/incomplete-migrations/migration2.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE foo;

--- a/ragtime.sql.resources/test/resources/migrations/20111202110600-create-foo-table.down.sql
+++ b/ragtime.sql.resources/test/resources/migrations/20111202110600-create-foo-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS foo;

--- a/ragtime.sql.resources/test/resources/migrations/20111202110600-create-foo-table.up.sql
+++ b/ragtime.sql.resources/test/resources/migrations/20111202110600-create-foo-table.up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE IF NOT EXISTS foo(id bigint);


### PR DESCRIPTION
Adds a new adapter for reading migrations from Java resources. Just like `ragtime.sql.files` except that the migration files get compiled into your JAR, which is pretty convenient sometimes.

Related to #29