### PR TITLE
Made hardcoded migration table name overridable

### DIFF
--- a/ragtime.sql/src/ragtime/sql/database.clj
+++ b/ragtime.sql/src/ragtime/sql/database.clj
@@ -15,13 +15,13 @@
 
 (require-jdbc 'sql)
 
-(def ^:private migrations-table "ragtime_migrations")
+(def ^:dynamic *migrations-table* "ragtime_migrations")
 
 (defn ^:internal ensure-migrations-table-exists [db]
   ;; TODO: is there a portable way to detect table existence?
   (sql/with-connection db
     (try
-      (sql/create-table migrations-table
+      (sql/create-table *migrations-table*
                         [:id "varchar(255)"]
                         [:created_at "varchar(32)"])
       (catch Exception _))))
@@ -35,20 +35,20 @@
   (add-migration-id [db id]
     (sql/with-connection db
       (ensure-migrations-table-exists db)
-      (sql/insert-values migrations-table
+      (sql/insert-values *migrations-table*
                          [:id :created_at]
                          [(str id) (format-datetime (Date.))])))
-  
+
   (remove-migration-id [db id]
     (sql/with-connection db
       (ensure-migrations-table-exists db)
-      (sql/delete-rows migrations-table ["id = ?" id])))
+      (sql/delete-rows *migrations-table* ["id = ?" id])))
 
   (applied-migration-ids [db]
     (sql/with-connection db
       (ensure-migrations-table-exists db)
       (sql/with-query-results results
-        ["SELECT id FROM ragtime_migrations ORDER BY created_at"]
+        [(format "SELECT id FROM %s ORDER BY created_at" *migrations-table*)]
         (vec (map :id results))))))
 
 (defmethod connection "jdbc" [url]


### PR DESCRIPTION
This comes in handy when using ragtime as a library. We have this problem in Joplin where we want to override the table name without having to copy most of the ragtime code over.