### PR TITLE
Issue 58 added one way to specify custom dir

### DIFF
--- a/ragtime.sql.files/src/ragtime/sql/files.clj
+++ b/ragtime.sql.files/src/ragtime/sql/files.clj
@@ -107,11 +107,17 @@
    :up   (run-sql-fn up)
    :down (run-sql-fn down)})
 
-(def ^:private default-dir "migrations")
+(def ^:private migrations-dir
+  (let
+      [proj (read-string (slurp "project.clj"))
+       ragtime-opts (nth proj (inc (.indexOf proj :ragtime)))]
+    (if-let [migrations-dir (:migrations-dir ragtime-opts)]
+      migrations-dir
+      "migrations")))
 
 (defn migrations
   "Return a list of migrations to apply."
-  ([] (migrations default-dir))
+  ([] (migrations migrations-dir))
   ([dir]
      (->> (get-migration-files dir)
           (map make-migration)


### PR DESCRIPTION
Not absolutely sure it fits with how ragtime is put together. But it matches what I think some people are asking for, to specify a directory from which to search for sql files via plugin options. I'm assuming here that a lot of people are using the leiningen plugin. In which case there is no way to pass a custom directory to load the sql files. So the sql.files namespace will use its default directory. What this addition does is look at the ragtime plugin options for a specified directory. Example usage would be:

```clj
:plugins [[ragtime/ragtime.lein "0.3.8"]]
:ragtime {:migrations  ragtime.sql.files/migrations
               :migrations-dir "src/sql/migs"
               :database "jdbc:postgresql://localhost:5432/test_ragtime?user=postgres"}
```

I'd like that better than having to wade through Joplin.