### PR TITLE
Ignore SQL comments.

### DIFF
--- a/ragtime.sql.files/test/ragtime/sql/test/files.clj
+++ b/ragtime.sql.files/test/ragtime/sql/test/files.clj
@@ -19,12 +19,24 @@
 
 (deftest test-sql-statements
   (are [x y] (= (sql-statements x) y)
-    "foo;bar"    ["foo" "bar"]
-    "foo;; bar;" ["foo" "bar"]
-    "'foo;bar'"  ["'foo;bar'"]
-    "`foo;bar`"  ["`foo;bar`"]
-    "\"fo;ba\""  ["\"fo;ba\""]
-    "'a;b' c; d" ["'a;b' c" "d"]))
+    "foo;bar"          ["foo" "bar"]
+    "foo;; bar;"       ["foo" "bar"]
+    "'foo;bar'"        ["'foo;bar'"]
+    "`foo;bar`"        ["`foo;bar`"]
+    "\"fo;ba\""        ["\"fo;ba\""]
+    "'a;b' c; d"       ["'a;b' c" "d"]
+    "-"                ["-"]
+    "--"               []
+    "--\na"            ["a"]
+    "a-b"              ["a-b"]
+    "a;-b;c-d;e-"      ["a" "-b" "c-d" "e-"]
+    "a'-'-'-';b"       ["a'-'-'-'" "b"]
+    "a;\nb\n"          ["a" "b"]
+    "a;\n--b;c"        ["a"]
+    "a;\n--b\nc"       ["a" "c"]
+    "a'--';b"          ["a'--'" "b"]
+    "a'b--c'--\"\n;d"  ["a'b--c'" "d"]
+    "a;\nb--'c\nd; e;" ["a" "b\nd" "e"]))
 
 (deftest test-migrations
   (testing "no migration directory"


### PR DESCRIPTION
Unescaped single quotes can be used in comments now.   Also, warn if a
non-blank SQL string results in an empty statement vector, since that
probably means the SQL parser failed.  Add addition test cases.

I know you're thinking of switch to edn, but this might still be useful.