### PR TITLE
Escape file separator in regex

### DIFF
--- a/ragtime.jdbc/src/ragtime/jdbc.clj
+++ b/ragtime.jdbc/src/ragtime/jdbc.clj
@@ -80,7 +80,7 @@
 (defn- file-extension [file]
   (re-find #"\.[^.]*$" (str file)))
 
-(let [pattern (re-pattern (str "([^" File/separator "]*)" File/separator "?$"))]
+(let [pattern (re-pattern (str "([^\\" File/separator "]*)\\" File/separator "?$"))]
   (defn- basename [file]
     (second (re-find pattern (str file)))))
 


### PR DESCRIPTION
Fixes "unclosed character class" error on Windows.