### PR TITLE
Fix usage of clojure.java.jdbc's create-table-ddl

### DIFF
--- a/ragtime.jdbc/project.clj
+++ b/ragtime.jdbc/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/java.jdbc "0.3.7"]
+                 [org.clojure/java.jdbc "0.5.8"]
                  [ragtime/ragtime.core "0.5.3"]
                  [resauce "0.1.0"]]
   :profiles

--- a/ragtime.jdbc/src/ragtime/jdbc.clj
+++ b/ragtime.jdbc/src/ragtime/jdbc.clj
@@ -14,8 +14,8 @@
 
 (defn- migrations-table-ddl [table-name]
   (sql/create-table-ddl table-name
-                        [:id "varchar(255)"]
-                        [:created_at "varchar(32)"]))
+                        [[:id "varchar(255)"]
+                         [:created_at "varchar(32)"]]))
 
 (defn- ensure-migrations-table-exists [db-spec migrations-table]
   (try
@@ -42,7 +42,7 @@
     (ensure-migrations-table-exists db-spec migrations-table)
     (sql/query db-spec
                [(str "SELECT id FROM " migrations-table " ORDER BY created_at")]
-               :row-fn :id)))
+               {:row-fn :id})))
 
 (alter-meta! #'->SqlDatabase assoc :no-doc true)
 (alter-meta! #'map->SqlDatabase assoc :no-doc true)

--- a/ragtime.jdbc/test/ragtime/jdbc_test.clj
+++ b/ragtime.jdbc/test/ragtime/jdbc_test.clj
@@ -23,10 +23,10 @@
                               {:migrations-table "migrations"})]
     (p/add-migration-id db "12")
     (is (= ["12"]
-           (sql/query (:db-spec db) ["SELECT * FROM migrations"] :row-fn :id)))))
+           (sql/query (:db-spec db) ["SELECT * FROM migrations"] {:row-fn :id})))))
 
 (defn table-names [db]
-  (set (sql/query (:db-spec db) ["SHOW TABLES"] :row-fn :table_name)))
+  (set (sql/query (:db-spec db) ["SHOW TABLES"] {:row-fn :table_name})))
 
 (deftest test-sql-migration
   (let [db (jdbc/sql-database {:connection (new-connection)})


### PR DESCRIPTION
I ran into an issue trying to process migrations with `[org.clojure/java.jdbc "0.6.0-alpha1"]`. Turns out there are some breaking changes coming down the pipe that will affect this library. I'm not sure if you want to merge this in quite yet; you might want to wait until a `"0.6.1"` release or something.

Some notes:

As of 0.5.6, `clojure.java.jdbc/create-table-ddl` expects column specs to
be wrapped in a single vector. This is now a breaking change (source: https://github.com/clojure/java.jdbc#change-log)

I'm not sure when the signature of `clojure.java.jdbc/query` changed, but it now expects a map of options as it's third argument.