### PR TITLE
Allow using db-spec containing an existing JDBC connection

### DIFF
--- a/ragtime.jdbc/test/ragtime/jdbc_test.clj
+++ b/ragtime.jdbc/test/ragtime/jdbc_test.clj
@@ -31,7 +31,7 @@
 (defn table-names [db]
   (set (sql/query (:db-spec db) ["SHOW TABLES"] {:row-fn :table_name})))
 
-(deftest test-sql-migration
+(defn test-sql-migration [db-spec]
   (let [db (jdbc/sql-database db-spec)
         m  (jdbc/sql-migration {:id   "01"
                                 :up   ["CREATE TABLE foo (id int)"]
@@ -40,6 +40,14 @@
     (is (= #{"RAGTIME_MIGRATIONS" "FOO"} (table-names db)))
     (core/rollback db m)
     (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))))
+
+(deftest test-sql-migration-using-db-spec
+  (test-sql-migration db-spec))
+
+(deftest test-sql-migration-using-db-spec-with-existing-connection
+  (sql/with-db-connection
+    [conn db-spec]
+    (test-sql-migration conn)))
 
 (deftest test-load-directory
   (let [db  (jdbc/sql-database db-spec)


### PR DESCRIPTION
This feature comes in handy when Ragtime is used inside existing connections created by a different JDBC wrapper or data source.

The syntax conforms to [wiki](https://github.com/weavejester/ragtime/wiki/Getting-Started) which states that configuration map has the same format as db-spec in [clojure.java.jdbc](https://clojure.github.io/java.jdbc/#clojure.java.jdbc/get-connection).

For instance this is now possible:

```clj
(with-open [raw-jdbc-conn (.getConnection data-source)]
  ,,,
  (let [db-spec {:connection raw-jdbc-conn}]
    (ragtime.repl/migrate {:datastore (ragtime.jdbc/sql-database db-spec)})))
```

This is something that we presumably broke by #106 which at the moment throws `java.sql.SQLException: Connection is closed` on subsequent queries after we do [`with-open` on the already open connection](https://github.com/weavejester/ragtime/blob/4d2a8e85089f6510a8fac61a9c511b04fb8837c0/ragtime.jdbc/src/ragtime/jdbc.clj#L21).