### PR TITLE
Limit tables to catalog specified on connection

### DIFF
--- a/ragtime.jdbc/src/ragtime/jdbc.clj
+++ b/ragtime.jdbc/src/ragtime/jdbc.clj
@@ -19,7 +19,7 @@
 (defn- get-table-names* [conn]
   (-> conn
       (.getMetaData)
-      (.getTables nil nil "%" nil)
+      (.getTables (.getCatalog conn) nil "%" nil)
       (sql/metadata-result {:row-fn :table_name})))
 
 (defn- get-table-names [db-spec]


### PR DESCRIPTION
`getTables` will retrieve all tables visible to the user. If two or more schemas share a common table name (and are visible to the user), without supplying `catalog` parameter, the list will contain duplicates. 

We can work around this issue by using `getCatalog` on `conn` to limit the tables to the schema on which it was initiated in the first place, without changing the function signature.