### PR TITLE
Sort JDBC migrations by ':id'

### DIFF
--- a/ragtime.jdbc/src/ragtime/jdbc.clj
+++ b/ragtime.jdbc/src/ragtime/jdbc.clj
@@ -132,10 +132,10 @@
         :down (vec (mapcat read-sql (sort-by str down)))}))))
 
 (defn- load-all-files [files]
-  (->> (sort-by str files)
-       (group-by file-extension)
+  (->> (group-by file-extension files)
        (vals)
-       (mapcat load-files)))
+       (mapcat load-files)
+       (sort-by :id)))
 
 (defn load-directory
   "Load a collection of Ragtime migrations from a directory."

--- a/ragtime.jdbc/test/migrations/006-test.edn
+++ b/ragtime.jdbc/test/migrations/006-test.edn
@@ -1,0 +1,2 @@
+{:up ["CREATE TABLE last_table (id int)"]
+ :down ["DROP TABLE last_table"]}

--- a/ragtime.jdbc/test/ragtime/jdbc_test.clj
+++ b/ragtime.jdbc/test/ragtime/jdbc_test.clj
@@ -54,9 +54,9 @@
         ms  (jdbc/load-directory "test/migrations")
         idx (core/into-index ms)]
     (core/migrate-all db idx ms)
-    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB"}
+    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE"}
            (table-names db)))
-    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test"]
+    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test"]
            (p/applied-migration-ids db)))
     (core/rollback-last db idx (count ms))
     (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))
@@ -67,9 +67,9 @@
         ms  (jdbc/load-resources "migrations")
         idx (core/into-index ms)]
     (core/migrate-all db idx ms)
-    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB"}
+    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE"}
            (table-names db)))
-    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test"]
+    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test"]
            (p/applied-migration-ids db)))
     (core/rollback-last db idx (count ms))
     (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))


### PR DESCRIPTION
See #111.
