### PR TITLE
Add migration strategy useful for continuous delivery

### DIFF
--- a/core/test/ragtime/strategy_test.clj
+++ b/core/test/ragtime/strategy_test.clj
@@ -23,7 +23,8 @@
     [] [:a :b] [[:migrate :a] [:migrate :b]])
   (are [a m] (thrown? clojure.lang.ExceptionInfo (raise-error a m))
     [:a] [:b]
-    [:a :b :c] [:a :d :c]))
+    [:a :b :c] [:a :d :c]
+    [:a :b :c] [:a]))
 
 (deftest rebase-test
   (are [a m r] (= (rebase a m) r)
@@ -36,3 +37,21 @@
     [:a] [:b] [[:rollback :a] [:migrate :b]]
     [:a :b :c] [:a :d :c] [[:rollback :c] [:rollback :b]
                            [:migrate :d] [:migrate :c]]))
+
+(deftest ignore-future-test
+  (testing "Compatible migrations (same as raise-error)"
+    (are [a m r] (= (ignore-future a m) r)
+      [:a] [:a] []
+      [] [] []
+      [:a :b] [:a :b] []
+      [:a] [:a :b] [[:migrate :b]]
+      [:a] [:a :b :c] [[:migrate :b] [:migrate :c]]
+      [] [:a :b] [[:migrate :a] [:migrate :b]]))
+  (testing "Future migrations are ok"
+    (are [a m r] (= (ignore-future a m) r)
+      [:a :b :c] [:a] []))
+  (testing "Incompatible migrations"
+    (are [a m] (thrown? clojure.lang.ExceptionInfo (ignore-future a m))
+      [:a] [:b]
+      [:a :b :c] [:a :d :c]
+      [:a :b :c] [:a :c :b])))


### PR DESCRIPTION
Blue/green deployments is a common technique used in continuous delivery, which basically means that two versions of an application running at the same time against the same database.

The existing raise-error migration strategy is not adequate for this scenario as if the old version of the application is restarted, the old version will refuse to start as it will find the new (future) migrations applied and raise an error.

With this new "ignore-future" migration, the old version of the application will expect that some "future" migrations have already been applied and do not raise an error in this case.