### PR TITLE
issue-142: ensuring tables resultset will be closed

### DIFF
--- a/jdbc/src/ragtime/jdbc.clj
+++ b/jdbc/src/ragtime/jdbc.clj
@@ -18,10 +18,10 @@
                          [:created_at "varchar(32)"]]))
 
 (defn- get-table-metadata* [^Connection conn]
-  (-> conn
-      (.getMetaData)
-      (.getTables (.getCatalog conn) nil "%" nil)
-      (sql/metadata-result)))
+  (with-open [tables (-> conn
+                         (.getMetaData)
+                         (.getTables (.getCatalog conn) nil "%" nil))]
+    (sql/metadata-result tables)))
 
 (defn- get-table-metadata [db-spec]
   (if-let [conn (sql/db-find-connection db-spec)]


### PR DESCRIPTION
Closes #142.

## Testing

I built a SNAPSHOT and verified in my own project that the chatty warnings issued by my driver given the leaking ResultSet no longer occurred. 