### PR TITLE
Fix warnings on unnecessary reflection calls

### DIFF
--- a/jdbc/project.clj
+++ b/jdbc/project.clj
@@ -7,6 +7,6 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/java.jdbc "0.5.8"]
                  [ragtime/core "0.8.1"]
-                 [resauce "0.1.0"]]
+                 [resauce "0.2.0"]]
   :profiles
   {:dev {:dependencies [[com.h2database/h2 "1.3.160"]]}})


### PR DESCRIPTION
Hi James!

Here's the application of [this fix in resauce](https://github.com/weavejester/resauce/pull/8) to the `ragtime` itself, which I originally discovered this issue with.

There's a single commit with a message is under 50 characters.

Cheers,
Mark