### PR TITLE
Fix #147 - use the newer, actively developed next-jdbc.

### DIFF
--- a/next.jdbc/project.clj
+++ b/next.jdbc/project.clj
@@ -1,0 +1,12 @@
+(defproject ragtime/next.jdbc "0.8.1"
+  :description "Ragtime migrations for next.jdbc"
+  :url "https://github.com/weavejester/ragtime"
+  :scm {:dir ".."}
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [com.github.seancorfield/next.jdbc "1.2.737"]
+                 [ragtime/core "0.8.1"]
+                 [resauce "0.1.0"]]
+  :profiles
+  {:dev {:dependencies [[com.h2database/h2 "1.4.200"]]}})

--- a/next.jdbc/src/ragtime/next_jdbc.clj
+++ b/next.jdbc/src/ragtime/next_jdbc.clj
@@ -1,0 +1,170 @@
+(ns ragtime.next-jdbc
+  "Functions for loading SQL migrations and applying them to a SQL database."
+  (:refer-clojure :exclude [load-file])
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [next.jdbc :as jdbc]
+            [next.jdbc.default-options]
+            [next.jdbc.result-set :as rs]
+            [next.jdbc.sql :as sql]
+            [clojure.string :as str]
+            [ragtime.protocols :as p]
+            [resauce.core :as resauce])
+  (:import [java.io File]
+           [java.sql Connection]
+           [java.text SimpleDateFormat]
+           [java.util Date]))
+
+;; Returns unqualified maps as some databases (e.g. Oracle) can only return them
+(defn- get-table-metadata* [^Connection c]
+  (-> (.getMetaData c)
+      (.getTables (.getCatalog c) nil nil (into-array ["TABLE"]))
+      (rs/datafiable-result-set c {:builder-fn rs/as-unqualified-lower-maps})))
+
+(defn- get-table-metadata [datasource]
+  (cond
+    (instance? java.sql.Connection datasource)
+    (get-table-metadata* datasource)
+
+    (next.jdbc.default-options/wrapped-connection? datasource)
+    (get-table-metadata* (:connectable datasource))
+
+    :else
+    (with-open [conn (jdbc/get-connection datasource)]
+      (get-table-metadata* conn))))
+
+(defn- metadata-matches-table?
+  [^String table-name {:keys [table_schem table_name]}]
+  (.equalsIgnoreCase table-name
+                     (if (.contains table-name ".")
+                       (str table_schem "." table_name)
+                       table_name)))
+
+(defn- table-exists? [datasource ^String table-name]
+  (some (partial metadata-matches-table? table-name)
+    (get-table-metadata datasource)))
+
+(defn- ensure-migrations-table-exists [datasource migrations-table]
+  (when-not (table-exists? datasource migrations-table)
+    (let [sql (str "create table " migrations-table
+                " (id varchar(255), created_at varchar(32))")]
+      (jdbc/execute! datasource [sql]))))
+
+(defn- format-datetime [^Date dt]
+  (-> (SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss.SSS")
+      (.format dt)))
+
+(defrecord SqlDatabase [datasource migrations-table]
+  p/DataStore
+  (add-migration-id [_ id]
+    (ensure-migrations-table-exists datasource migrations-table)
+    (sql/insert! datasource migrations-table
+      {:id         (str id)
+       :created_at (format-datetime (Date.))}))
+
+  (remove-migration-id [_ id]
+    (ensure-migrations-table-exists datasource migrations-table)
+    (sql/delete! datasource migrations-table ["id = ?" id]))
+
+  (applied-migration-ids [_]
+    (ensure-migrations-table-exists datasource migrations-table)
+    (let [sql [(str "SELECT id FROM " migrations-table " ORDER BY created_at")]]
+      (->> (sql/query datasource sql {:builder-fn rs/as-unqualified-lower-maps})
+           (map :id)))))
+
+(defn sql-database
+  "Given a datasource and a map of options, return a Migratable database.
+  The following options are allowed:
+
+  :migrations-table - the name of the table to store the applied migrations
+                      (defaults to ragtime_migrations). You must include the
+                      schema name if your DB supports that and you are not
+                      using the default one (ex.: myschema.migrations)"
+  ([datasource]
+    (sql-database datasource {}))
+  ([datasource options]
+    (->SqlDatabase datasource (:migrations-table options "ragtime_migrations"))))
+
+(defn- execute-sql! [datasource statements transaction?]
+  (if transaction?
+    (jdbc/with-transaction [tx datasource]
+      (doseq [s statements]
+        (jdbc/execute! (jdbc/with-options tx (:options datasource)) [s])))
+    (doseq [s statements]
+      (jdbc/execute! datasource [s]))))
+
+(defrecord SqlMigration [id up down transactions]
+  p/Migration
+  (id [_] id)
+  (run-up! [_ db]
+    (execute-sql! (:datasource db)
+      up
+      (contains? #{:up :both true} transactions)))
+  (run-down! [_ db]
+    (execute-sql! (:datasource db)
+      down
+      (contains? #{:down :both true} transactions))))
+
+(defn sql-migration
+  "Create a Ragtime migration from a map with a unique :id, and :up and :down
+  keys that map to ordered collection of SQL strings."
+  [migration-map]
+  (map->SqlMigration migration-map))
+
+(defn- file-extension [file]
+  (re-find #"\.[^.]*$" (str file)))
+
+(let [pattern (re-pattern (str "([^\\/]*)\\/?$"))]
+  (defn- basename [file]
+    (second (re-find pattern (str file)))))
+
+(defn- remove-extension [file]
+  (second (re-matches #"(.*)\.[^.]*" (str file))))
+
+(defmulti load-files
+  "Given an collection of files with the same extension, return a ordered
+  collection of migrations. Dispatches on extension (e.g. \".edn\"). Extend
+  this multimethod to support new formats for specifying SQL migrations."
+  (fn [files] (file-extension (first files))))
+
+(defmethod load-files :default [files])
+
+(defmethod load-files ".edn" [files]
+  (for [file files]
+    (-> (slurp file)
+        (edn/read-string)
+        (update-in [:id] #(or % (-> file basename remove-extension)))
+        (update-in [:transactions] (fnil identity :both))
+        (sql-migration))))
+
+(defn- sql-file-parts [file]
+  (rest (re-matches #"(.*?)\.(up|down)(?:\.(\d+))?\.sql" (str file))))
+
+(defn- read-sql [file]
+  (str/split (slurp file) #"(?m)\n\s*--;;\s*\n"))
+
+(defmethod load-files ".sql" [files]
+  (for [[id files] (->> files
+                        (group-by (comp first sql-file-parts))
+                        (sort-by key))]
+    (let [{:strs [up down]} (group-by (comp second sql-file-parts) files)]
+      (sql-migration
+        {:id   (basename id)
+         :up   (vec (mapcat read-sql (sort-by str up)))
+         :down (vec (mapcat read-sql (sort-by str down)))}))))
+
+(defn- load-all-files [files]
+  (->> (group-by file-extension files)
+       (vals)
+       (mapcat load-files)
+       (sort-by :id)))
+
+(defn load-directory
+  "Load a collection of Ragtime migrations from a directory."
+  [path]
+  (load-all-files (map #(.toURI ^File %) (file-seq (io/file path)))))
+
+(defn load-resources
+  "Load a collection of Ragtime migrations from a classpath prefix."
+  [path]
+  (load-all-files (resauce/resource-dir path)))

--- a/next.jdbc/test/migrations/001-test.edn
+++ b/next.jdbc/test/migrations/001-test.edn
@@ -1,0 +1,2 @@
+{:up ["CREATE TABLE foo (id int)"]
+ :down ["DROP TABLE foo"]}

--- a/next.jdbc/test/migrations/002-test.edn
+++ b/next.jdbc/test/migrations/002-test.edn
@@ -1,0 +1,3 @@
+{:id "002-bar"
+ :up ["CREATE TABLE bar (id int)"]
+ :down ["DROP TABLE bar"]}

--- a/next.jdbc/test/migrations/003-test.down.sql
+++ b/next.jdbc/test/migrations/003-test.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE baz;

--- a/next.jdbc/test/migrations/003-test.up.sql
+++ b/next.jdbc/test/migrations/003-test.up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE baz (id int);

--- a/next.jdbc/test/migrations/004-test.down.1.sql
+++ b/next.jdbc/test/migrations/004-test.down.1.sql
@@ -1,0 +1,1 @@
+DROP TABLE quzb;

--- a/next.jdbc/test/migrations/004-test.down.2.sql
+++ b/next.jdbc/test/migrations/004-test.down.2.sql
@@ -1,0 +1,1 @@
+DROP TABLE quza;

--- a/next.jdbc/test/migrations/004-test.up.1.sql
+++ b/next.jdbc/test/migrations/004-test.up.1.sql
@@ -1,0 +1,1 @@
+CREATE TABLE quza (id int);

--- a/next.jdbc/test/migrations/004-test.up.2.sql
+++ b/next.jdbc/test/migrations/004-test.up.2.sql
@@ -1,0 +1,1 @@
+CREATE TABLE quzb (id int);

--- a/next.jdbc/test/migrations/005-test.down.sql
+++ b/next.jdbc/test/migrations/005-test.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE quxa;
+--;;
+DROP TABLE quxb;

--- a/next.jdbc/test/migrations/005-test.up.sql
+++ b/next.jdbc/test/migrations/005-test.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE quxa (id int);
+--;;
+CREATE TABLE quxb (id int);

--- a/next.jdbc/test/migrations/006-test.edn
+++ b/next.jdbc/test/migrations/006-test.edn
@@ -1,0 +1,2 @@
+{:up ["CREATE TABLE last_table (id int)"]
+ :down ["DROP TABLE last_table"]}

--- a/next.jdbc/test/ragtime/next_jdbc_test.clj
+++ b/next.jdbc/test/ragtime/next_jdbc_test.clj
@@ -1,0 +1,112 @@
+(ns ragtime.next-jdbc-test
+  (:require [clojure.test :refer :all]
+            [ragtime.next-jdbc :as jdbc]
+            [ragtime.core :as core]
+            [ragtime.protocols :as p]
+            [clojure.java.io :as io]
+            [next.jdbc :as n.j]
+            [next.jdbc.sql :as sql]))
+
+(def datasource {:jdbcUrl "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1"})
+
+(use-fixtures :each (fn reset-db [f]
+                      (n.j/execute! datasource ["DROP ALL OBJECTS"])
+                      (f)))
+
+(deftest test-add-migrations
+  (let [db (jdbc/sql-database datasource)]
+    (p/add-migration-id db "12")
+    (p/add-migration-id db "13")
+    (p/add-migration-id db "20")
+    (is (= ["12" "13" "20"] (p/applied-migration-ids db)))
+    (p/remove-migration-id db "13")
+    (is (= ["12" "20"] (p/applied-migration-ids db)))))
+
+(deftest test-migrations-table
+  (let [db (jdbc/sql-database datasource
+             {:migrations-table "migrations"})]
+    (p/add-migration-id db "12")
+    (is (= ["12"]
+           (map :MIGRATIONS/ID (sql/query (:datasource db)
+                                 ["SELECT * FROM migrations"])))))
+
+  (n.j/execute! datasource ["CREATE SCHEMA myschema"])
+  (let [db (jdbc/sql-database datasource
+             {:migrations-table "myschema.migrations"})]
+    (p/add-migration-id db "20")
+    (p/add-migration-id db "21")
+    (is (= ["20" "21"]
+           (map :MIGRATIONS/ID (n.j/execute! (:datasource db)
+                                 ["SELECT * FROM myschema.migrations"]))))))
+
+(defn table-names [db]
+  (set (map :TABLES/TABLE_NAME (sql/query (:datasource db) ["SHOW TABLES"]))))
+
+(defn test-sql-migration [connectable migration-extras]
+  (let [db (jdbc/sql-database connectable)
+        m  (jdbc/sql-migration
+             (merge {:id   "01"
+                     :up   ["CREATE TABLE foo (id int)"]
+                     :down ["DROP TABLE foo"]}
+               migration-extras))]
+    (core/migrate db m)
+    (is (= #{"RAGTIME_MIGRATIONS" "FOO"} (table-names db)))
+    (core/rollback db m)
+    (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))))
+
+(deftest test-sql-migration-using-db-spec
+  (test-sql-migration datasource {}))
+
+(deftest test-sql-migration-without-transaction
+  (test-sql-migration datasource {:transactions false}))
+
+(deftest test-sql-migration-with-up-transaction
+  (test-sql-migration datasource {:transactions :up}))
+
+(deftest test-sql-migration-with-down-transaction
+  (test-sql-migration datasource {:transactions :down}))
+
+(deftest test-sql-migration-with-both-transaction
+  (test-sql-migration datasource {:transactions :both})
+  (test-sql-migration datasource {:transactions true}))
+
+(deftest test-sql-migration-using-db-spec-with-existing-connection
+  (with-open [conn (n.j/get-connection datasource)]
+    (test-sql-migration conn {})))
+
+(deftest test-load-directory
+  (let [db  (jdbc/sql-database datasource)
+        ms  (jdbc/load-directory "test/migrations")
+        idx (core/into-index ms)]
+    (core/migrate-all db idx ms)
+    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ"
+             "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE"}
+           (table-names db)))
+    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test"]
+           (p/applied-migration-ids db)))
+    (core/rollback-last db idx (count ms))
+    (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))
+    (is (empty? (p/applied-migration-ids db)))))
+
+(deftest test-load-resources
+  (let [db  (jdbc/sql-database datasource)
+        ms  (jdbc/load-resources "migrations")
+        idx (core/into-index ms)]
+    (core/migrate-all db idx ms)
+    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ"
+             "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE"}
+           (table-names db)))
+    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test"]
+           (p/applied-migration-ids db)))
+    (core/rollback-last db idx (count ms))
+    (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))
+    (is (empty? (p/applied-migration-ids db)))))
+
+(deftest test-migration-ordering
+  (let [ids   (for [i (range 10000)] (format "%04d-test" i))
+        files (mapcat (fn [id] [(str id ".up.sql") (str id ".down.sql")]) ids)]
+    (with-redefs [file-seq (constantly (map io/file (shuffle files)))
+                  slurp    (constantly "SELECT 1;")]
+      (let [migrations (jdbc/load-directory "foo")]
+        (is (= (count migrations) 10000))
+        (is (= (map :id migrations) ids))))))


### PR DESCRIPTION
Thus any "connectable" can be used instead of just a db-spec.

next-jdbc requires Clojure 1.10+

Fixes #147

Notice that I had to remove `ragtime.jdbc.migrations/create-table` because jdbc-next lacks the DDL functions of clojure.java.jdbc. Implementing data -> DDL here does not seem appropriate. If users want this, they can use HoneySQL or similar themselves, IMO.