### PR TITLE
Make migrate-all interruptible

### DIFF
--- a/core/src/ragtime/core.clj
+++ b/core/src/ragtime/core.clj
@@ -56,6 +56,10 @@
          index    (into-index index migrations)
          applied  (p/applied-migration-ids store)]
      (doseq [[action migration-id] (strategy applied (map p/id migrations))]
+       (when (.isInterrupted (Thread/currentThread))
+         (throw (InterruptedException.
+                 (str "Stopping running migrations before " migration-id
+                      " because the current thread has been interrupted"))))
        (reporter store ({:migrate :up, :rollback :down} action) migration-id)
        (case action
          :migrate  (migrate store (index migration-id))


### PR DESCRIPTION
Using Thread.interrupt, which sets its `isInterrupted` flag, is a common way to ask threads to stop gracefully, for example on app shutdown. Ragtime should respect that.

We could simply skip the remaining migrations but I feel it is better to throw an exception so that the caller can be informed that the migrations have not been applied fully.