### PR TITLE
Allow a single space for the SQL separator marker '--;;'

### DIFF
--- a/jdbc/src/ragtime/jdbc.clj
+++ b/jdbc/src/ragtime/jdbc.clj
@@ -128,7 +128,7 @@
   (rest (re-matches #"(.*?)\.(up|down)(?:\.(\d+))?\.sql" (str file))))
 
 (defn- read-sql [file]
-  (str/split (slurp file) #"(?m)\n\s*--;;\s*\n"))
+  (str/split (slurp file) #"(?m)\n\s*--\s?;;\s*\n"))
 
 (defmethod load-files ".sql" [files]
   (for [[id files] (->> files

--- a/jdbc/test/migrations/007-test.down.sql
+++ b/jdbc/test/migrations/007-test.down.sql
@@ -1,0 +1,6 @@
+--
+-- ISSUE 159 Test
+--
+DROP TABLE quxc;
+-- ;;
+DROP TABLE quxd;

--- a/jdbc/test/migrations/007-test.up.sql
+++ b/jdbc/test/migrations/007-test.up.sql
@@ -1,0 +1,6 @@
+--
+-- ISSUE 159 Test
+--
+CREATE TABLE quxc (id int);
+-- ;;
+CREATE TABLE quxd (id int);

--- a/jdbc/test/ragtime/jdbc_test.clj
+++ b/jdbc/test/ragtime/jdbc_test.clj
@@ -77,9 +77,9 @@
         ms  (jdbc/load-directory "test/migrations")
         idx (core/into-index ms)]
     (core/migrate-all db idx ms)
-    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE"}
+    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE" "QUXC" "QUXD"}
            (table-names db)))
-    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test"]
+    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test" "007-test"]
            (p/applied-migration-ids db)))
     (core/rollback-last db idx (count ms))
     (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))
@@ -90,9 +90,9 @@
         ms  (jdbc/load-resources "migrations")
         idx (core/into-index ms)]
     (core/migrate-all db idx ms)
-    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE"}
+    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE" "QUXC" "QUXD"}
            (table-names db)))
-    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test"]
+    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test" "007-test"]
            (p/applied-migration-ids db)))
     (core/rollback-last db idx (count ms))
     (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))

--- a/next-jdbc/src/ragtime/next_jdbc.clj
+++ b/next-jdbc/src/ragtime/next_jdbc.clj
@@ -163,7 +163,7 @@
   (rest (re-matches #"(.*?)\.(up|down)(?:\.(\d+))?\.sql" (str file))))
 
 (defn- read-sql [file]
-  (str/split (slurp file) #"(?m)\n\s*--;;\s*\n"))
+  (str/split (slurp file) #"(?m)\n\s*--\s?;;\s*\n"))
 
 (defmethod load-files ".sql" [files]
   (for [[id files] (->> files

--- a/next-jdbc/test/migrations/007-test.down.sql
+++ b/next-jdbc/test/migrations/007-test.down.sql
@@ -1,0 +1,6 @@
+--
+-- ISSUE 159 Test
+--
+DROP TABLE quxc;
+-- ;;
+DROP TABLE quxd;

--- a/next-jdbc/test/migrations/007-test.up.sql
+++ b/next-jdbc/test/migrations/007-test.up.sql
@@ -1,0 +1,6 @@
+--
+-- ISSUE 159 Test
+--
+CREATE TABLE quxc (id int);
+-- ;;
+CREATE TABLE quxd (id int);

--- a/next-jdbc/test/ragtime/next_jdbc_test.clj
+++ b/next-jdbc/test/ragtime/next_jdbc_test.clj
@@ -94,9 +94,9 @@
         idx (core/into-index ms)]
     (core/migrate-all db idx ms)
     (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ"
-             "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE"}
+             "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE" "QUXC" "QUXD"}
            (table-names db)))
-    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test"]
+    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test" "007-test"]
            (p/applied-migration-ids db)))
     (core/rollback-last db idx (count ms))
     (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))
@@ -108,9 +108,9 @@
         idx (core/into-index ms)]
     (core/migrate-all db idx ms)
     (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ"
-             "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE"}
+             "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE" "QUXC" "QUXD"}
            (table-names db)))
-    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test"]
+    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test" "007-test"]
            (p/applied-migration-ids db)))
     (core/rollback-last db idx (count ms))
     (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))


### PR DESCRIPTION
This commit loosens the restriction on the SQL separator marker from being '--;;' to also allow '-- ;;'. In doing so, it aids those developers who are using ragtime for MySQL migrations as MySQL requires that comments starting with '--' are immediately followed by a space (or control character) before any other character.

fixes #159

-=david=-