### PR TITLE
next-jdbc: Unbreak metadata table check when not using a schema name.

### DIFF
--- a/next-jdbc/src/ragtime/next_jdbc.clj
+++ b/next-jdbc/src/ragtime/next_jdbc.clj
@@ -54,8 +54,8 @@
   [^String table-name {:keys [table_schem table_name]}]
   (.equalsIgnoreCase table-name
                      (if (.contains table-name ".")
-                       (str table_schem "." table_name)
-                       table_name)))
+                       table_name
+                       (str table_schem "." table_name))))
 
 (defn- table-exists-via-metadata-scan? [datasource ^String table-name]
   (let [{:keys [tables quote]} (get-db-metadata datasource)


### PR DESCRIPTION
We stumbled across this in the `next-jdbc` variant of ragtime: When using a unqualified migration-table-name with OracleDB (which supports schemas), we ended up in the wrong schema for our user.

This unbreaks this behaviour: When the name contains **no** space, it prepends the schema (not the other way around).

Possibly related to #80 and #123